### PR TITLE
Fix env vars bugs :bug:

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NODE_ENV="production/development/test"
+VUE_APP_ROOT_API="http://url.here:port/version"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+.env
+.env.production

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,6 +1,6 @@
 class Api {
   constructor() {
-    this.apiUrl = "http://localhost:8000/api/v1";
+    this.apiUrl = process.env.VUE_APP_ROOT_API;
   }
 
   get(endpoint) {


### PR DESCRIPTION
**Qué se hizo:**

* Se corrigió el error que detectó Facu, el cual entró en el PR #9 por falta de revisión de código (mala mía, tomá otro gusanito igual :beetle:). El error es que estabamos pasando la URL derecho de la API, la cual debía ser guardada en algún archivo de entorno que se cargue de acuerdo a la ejecución.

**Cómo probarlo:**

Descargando la rama, se debe crear en el root del proyecto un archivo de texto plano con el nombre _.env_. En el mismo, se debe copiar las claves que tiene el archivo _.env.example_ y setear lo siguiente:

```
NODE_ENV="development"
VUE_APP_ROOT_API="http://localhost:8000/api/v1"
```
Luego, correr un `npm run serve` y meter un `console.log(process.env.VUE_APP_ROOT_API);` en el navegador. Si devuelve la URL que le pasamos en el .env, ¡significa que se están cargando las claves definidad!

**Wiki**: [Variables de entorno](https://github.com/tesis-cabal-cugno-moreyra/webapp/wiki/Variables-de-entorno)

![image](https://user-images.githubusercontent.com/18491478/91778762-e3249200-ebc9-11ea-946c-9c6f9a4aec04.png)
