### PR TITLE
038 store domain config alias on vuex

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,14 +14,19 @@
 import { mapGetters } from "vuex";
 import NavBar from "@/components/NavBar.vue";
 import authServices from "@/services/authServices";
+import domainConfigServices from "@/services/domainConfigServices";
 
 export default {
   name: "App",
-
+  data: function() {
+    return {
+      aliases: null
+    };
+  },
   components: {
     NavBar
   },
-  async beforeCreate() {
+  beforeCreate() {
     if (authServices.getUser()) {
       this.$store.dispatch("restAuth/updateUser", authServices.getUser());
       this.$store.dispatch(
@@ -29,25 +34,32 @@ export default {
         authServices.getToken()
       );
     }
-    await this.$store
-      .dispatch("domainConfig/getDomainConfig")
-      .then(response => {
-        console.log(response.data);
-      })
-      .catch(e => {
-        console.log(e);
-      });
-    console.log("///");
-    await this.$store.dispatch("domainConfig/getDomainConfigAlias");
   },
-  created() {
+  async created() {
     this.$vuetify.theme.dark = true;
+    if (this.aliases === null) {
+      await this.$store
+        .dispatch("domainConfig/getDomainConfig")
+        .then(response => {
+          console.log(response.data);
+        })
+        .catch(e => {
+          console.log(e);
+        });
+      let aliases = domainConfigServices.getDomainConfigAlias(
+        this.domainConfig
+      );
+      console.log(aliases);
+      this.aliases = aliases;
+    }
   },
+
   computed: {
     ...mapGetters({
       isLoading: "uiParams/isLoading",
       isNavBarEnable: "uiParams/showNavBar",
-      isLoggedIn: "restAuth/isLoggedIn"
+      isLoggedIn: "restAuth/isLoggedIn",
+      domainConfig: "domainConfig/domainConfig"
     }),
     showNavBar: function() {
       if (this.isLoggedIn && this.isNavBarEnable) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,16 +31,19 @@ export default {
   },
   async created() {
     this.$vuetify.theme.dark = true;
-    await this.$store.dispatch("domainConfig/getDomainConfig").catch(e => {
-      console.log(e);
-    });
+    if (this.domainConfig === null) {
+      await this.$store.dispatch("domainConfig/getDomainConfig").catch(e => {
+        console.log(e);
+      });
+    }
   },
 
   computed: {
     ...mapGetters({
       isLoading: "uiParams/isLoading",
       isNavBarEnable: "uiParams/showNavBar",
-      isLoggedIn: "restAuth/isLoggedIn"
+      isLoggedIn: "restAuth/isLoggedIn",
+      domainConfig: "domainConfig/domainConfig"
     }),
     showNavBar: function() {
       if (this.isLoggedIn && this.isNavBarEnable) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@ export default {
   components: {
     NavBar
   },
-  beforeCreate() {
+  async beforeCreate() {
     if (authServices.getUser()) {
       this.$store.dispatch("restAuth/updateUser", authServices.getUser());
       this.$store.dispatch(
@@ -29,6 +29,16 @@ export default {
         authServices.getToken()
       );
     }
+    await this.$store
+      .dispatch("domainConfig/getDomainConfig")
+      .then(response => {
+        console.log(response.data);
+      })
+      .catch(e => {
+        console.log(e);
+      });
+    console.log("///");
+    await this.$store.dispatch("domainConfig/getDomainConfigAlias");
   },
   created() {
     this.$vuetify.theme.dark = true;

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,8 +29,9 @@ export default {
       );
     }
   },
-  async created() {
+  async mounted() {
     this.$vuetify.theme.dark = true;
+    console.log(this.domainConfig);
     if (this.domainConfig === null) {
       await this.$store.dispatch("domainConfig/getDomainConfig").catch(e => {
         console.log(e);

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,15 +14,9 @@
 import { mapGetters } from "vuex";
 import NavBar from "@/components/NavBar.vue";
 import authServices from "@/services/authServices";
-import domainConfigServices from "@/services/domainConfigServices";
 
 export default {
   name: "App",
-  data: function() {
-    return {
-      aliases: null
-    };
-  },
   components: {
     NavBar
   },
@@ -37,29 +31,16 @@ export default {
   },
   async created() {
     this.$vuetify.theme.dark = true;
-    if (this.aliases === null) {
-      await this.$store
-        .dispatch("domainConfig/getDomainConfig")
-        .then(response => {
-          console.log(response.data);
-        })
-        .catch(e => {
-          console.log(e);
-        });
-      let aliases = domainConfigServices.getDomainConfigAlias(
-        this.domainConfig
-      );
-      console.log(aliases);
-      this.aliases = aliases;
-    }
+    await this.$store.dispatch("domainConfig/getDomainConfig").catch(e => {
+      console.log(e);
+    });
   },
 
   computed: {
     ...mapGetters({
       isLoading: "uiParams/isLoading",
       isNavBarEnable: "uiParams/showNavBar",
-      isLoggedIn: "restAuth/isLoggedIn",
-      domainConfig: "domainConfig/domainConfig"
+      isLoggedIn: "restAuth/isLoggedIn"
     }),
     showNavBar: function() {
       if (this.isLoggedIn && this.isNavBarEnable) {

--- a/src/services/domainConfigServices.js
+++ b/src/services/domainConfigServices.js
@@ -1,0 +1,11 @@
+export default {
+  getAdminAliases(domainConfig) {
+    return domainConfig.domainConfig.adminAlias;
+  },
+  getSupervisorAliases() {
+    return "Supervisor";
+  },
+  getResourceAliases() {
+    return "Bombero";
+  }
+};

--- a/src/services/domainConfigServices.js
+++ b/src/services/domainConfigServices.js
@@ -5,15 +5,13 @@ export default {
   getSupervisorAliases(domainConfig) {
     let supervisorAliases = [];
     domainConfig.supervisorAliases.forEach(supervisorAlias => {
-      console.log(supervisorAlias.name);
       supervisorAliases.push(supervisorAlias.name);
     });
     return supervisorAliases;
   },
   getResourceAliases(domainConfig) {
     let resourceAliases = [];
-    domainConfig.supervisorAliases.forEach(resourceAlias => {
-      console.log(resourceAlias.name);
+    domainConfig.resourceTypes.forEach(resourceAlias => {
       resourceAliases.push(resourceAlias.name);
     });
     return resourceAliases;
@@ -22,7 +20,6 @@ export default {
     let adminAlias = this.getAdminAliases(domainConfig);
     let supervisorAliases = this.getSupervisorAliases(domainConfig);
     let resourceAliases = this.getResourceAliases(domainConfig);
-    console.log(adminAlias);
     return {
       adminAlias: adminAlias,
       supervisorAliases: supervisorAliases,

--- a/src/services/domainConfigServices.js
+++ b/src/services/domainConfigServices.js
@@ -11,8 +11,12 @@ export default {
   },
   getResourceAliases(domainConfig) {
     let resourceAliases = [];
-    domainConfig.resourceTypes.forEach(resourceAlias => {
-      resourceAliases.push(resourceAlias.name);
+    domainConfig.incidentAbstractions.forEach(incidentAbstraction => {
+      incidentAbstraction.types.forEach(incidentType => {
+        incidentType.resourceTypes.forEach(resourceType => {
+          resourceAliases.push(resourceType.name);
+        });
+      });
     });
     return resourceAliases;
   },

--- a/src/services/domainConfigServices.js
+++ b/src/services/domainConfigServices.js
@@ -1,11 +1,32 @@
 export default {
   getAdminAliases(domainConfig) {
-    return domainConfig.domainConfig.adminAlias;
+    return domainConfig.adminAlias;
   },
-  getSupervisorAliases() {
-    return "Supervisor";
+  getSupervisorAliases(domainConfig) {
+    let supervisorAliases = [];
+    domainConfig.supervisorAliases.forEach(supervisorAlias => {
+      console.log(supervisorAlias.name);
+      supervisorAliases.push(supervisorAlias.name);
+    });
+    return supervisorAliases;
   },
-  getResourceAliases() {
-    return "Bombero";
+  getResourceAliases(domainConfig) {
+    let resourceAliases = [];
+    domainConfig.supervisorAliases.forEach(resourceAlias => {
+      console.log(resourceAlias.name);
+      resourceAliases.push(resourceAlias.name);
+    });
+    return resourceAliases;
+  },
+  getDomainConfigAlias(domainConfig) {
+    let adminAlias = this.getAdminAliases(domainConfig);
+    let supervisorAliases = this.getSupervisorAliases(domainConfig);
+    let resourceAliases = this.getResourceAliases(domainConfig);
+    console.log(adminAlias);
+    return {
+      adminAlias: adminAlias,
+      supervisorAliases: supervisorAliases,
+      resourcesAliases: resourceAliases
+    };
   }
 };

--- a/src/store/domain-config/actions.js
+++ b/src/store/domain-config/actions.js
@@ -1,4 +1,5 @@
 import api from "@/services/api";
+import domainConfigServices from "@/services/domainConfigServices";
 
 export default {
   getDomainAccessCode() {
@@ -39,6 +40,10 @@ export default {
       try {
         const domainConfigResponse = await api.get("/api/v1/domain-config/");
         this.commit("domainConfig/addDomainConfig", domainConfigResponse.data);
+        this.commit(
+          "domainConfig/addDomainConfigAliases",
+          domainConfigServices.getDomainConfigAlias(domainConfigResponse.data)
+        );
         return resolve(domainConfigResponse);
       } catch (e) {
         return reject(e);

--- a/src/store/domain-config/actions.js
+++ b/src/store/domain-config/actions.js
@@ -1,5 +1,4 @@
 import api from "@/services/api";
-import domainConfigServices from "@/services/domainConfigServices";
 
 export default {
   getDomainAccessCode() {
@@ -45,21 +44,5 @@ export default {
         return reject(e);
       }
     });
-  },
-  getDomainConfigAlias() {
-    setTimeout(console.log("Esperando..."), 3000);
-    const domainConfig = this.commit("domainConfig/retrieveDomainConfig");
-    console.log(domainConfig);
-    let adminAlias = domainConfigServices.getAdminAliases(domainConfig);
-    let supervisorAliases = domainConfigServices.getSupervisorAliases(
-      domainConfig
-    );
-    let resourceAliases = domainConfigServices.getResourceAliases(domainConfig);
-    console.log(adminAlias);
-    return {
-      adminAlias: adminAlias,
-      supervisorAliases: supervisorAliases,
-      resourcesAliases: resourceAliases
-    };
   }
 };

--- a/src/store/domain-config/actions.js
+++ b/src/store/domain-config/actions.js
@@ -1,4 +1,5 @@
 import api from "@/services/api";
+import domainConfigServices from "@/services/domainConfigServices";
 
 export default {
   getDomainAccessCode() {
@@ -44,5 +45,21 @@ export default {
         return reject(e);
       }
     });
+  },
+  getDomainConfigAlias() {
+    setTimeout(console.log("Esperando..."), 3000);
+    const domainConfig = this.commit("domainConfig/retrieveDomainConfig");
+    console.log(domainConfig);
+    let adminAlias = domainConfigServices.getAdminAliases(domainConfig);
+    let supervisorAliases = domainConfigServices.getSupervisorAliases(
+      domainConfig
+    );
+    let resourceAliases = domainConfigServices.getResourceAliases(domainConfig);
+    console.log(adminAlias);
+    return {
+      adminAlias: adminAlias,
+      supervisorAliases: supervisorAliases,
+      resourcesAliases: resourceAliases
+    };
   }
 };

--- a/src/store/domain-config/getters.js
+++ b/src/store/domain-config/getters.js
@@ -1,5 +1,8 @@
 export default {
   domainConfig(state) {
     return state.domainConfig;
+  },
+  aliases(state) {
+    return state.aliases;
   }
 };

--- a/src/store/domain-config/mutations.js
+++ b/src/store/domain-config/mutations.js
@@ -3,6 +3,7 @@ export default {
     state.domainConfig = domainConfig;
   },
   retrieveDomainConfig(state) {
-    return state.domainConfig;
+    let domainConfig = console.log(state.domainConfig.adminAlias);
+    return domainConfig;
   }
 };

--- a/src/store/domain-config/mutations.js
+++ b/src/store/domain-config/mutations.js
@@ -2,6 +2,9 @@ export default {
   addDomainConfig(state, domainConfig) {
     state.domainConfig = domainConfig;
   },
+  addDomainConfigAliases(state, aliases) {
+    state.aliases = aliases;
+  },
   retrieveDomainConfig(state) {
     let domainConfig = console.log(state.domainConfig.adminAlias);
     return domainConfig;

--- a/src/store/domain-config/mutations.js
+++ b/src/store/domain-config/mutations.js
@@ -4,9 +4,5 @@ export default {
   },
   addDomainConfigAliases(state, aliases) {
     state.aliases = aliases;
-  },
-  retrieveDomainConfig(state) {
-    let domainConfig = console.log(state.domainConfig.adminAlias);
-    return domainConfig;
   }
 };

--- a/src/store/domain-config/mutations.js
+++ b/src/store/domain-config/mutations.js
@@ -1,5 +1,8 @@
 export default {
   addDomainConfig(state, domainConfig) {
     state.domainConfig = domainConfig;
+  },
+  retrieveDomainConfig(state) {
+    return state.domainConfig;
   }
 };

--- a/src/store/domain-config/state.js
+++ b/src/store/domain-config/state.js
@@ -1,3 +1,4 @@
 export default {
-  domainConfig: null
+  domainConfig: null,
+  aliases: null
 };

--- a/src/store/domain-config/state.js
+++ b/src/store/domain-config/state.js
@@ -1,3 +1,3 @@
 export default {
-  domainConfig: {}
+  domainConfig: null
 };


### PR DESCRIPTION
close #38 
Se implementa servicio para manipular los alias. Cuando se actualiza en Vuex el domainConfig, actualiza también los aliases. De esa forma nos aseguramos de ser consistentes con estos dos objetos. Ahora lo que se hace es llamar siempre al domainConfig, desde App.vue para cargarlo. Se le pega a la API solamente cuando no se encuentra nada almacenado en la domainConfig de Vuex.

![Captura de pantalla de 2020-10-05 18-42-44](https://user-images.githubusercontent.com/18491478/95135962-ad7c4700-073b-11eb-82d6-76c96ad4c118.png)

PD: adjunto un Bugs Bunny, el único bug que van a encontrar en este código ;)
![image](https://user-images.githubusercontent.com/18491478/95136902-61320680-073d-11eb-9daf-4eee1048559d.png)
