### PR TITLE
Refactor ResourceStatistics view

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,7 +13,7 @@ import IncidentsView from "@/views/IncidentsView";
 import IncidentDetails from "@/components/IncidentDetails";
 import IncidentMap from "@/views/IncidentMap";
 import UserManager from "@/views/UserManager";
-import StatisticsView from "@/views/StatisticsView";
+import ResourceStatistics from "@/views/ResourceStatistics";
 import IncidentMetrics from "@/views/IncidentMetrics";
 
 Vue.use(VueRouter);
@@ -136,9 +136,9 @@ const routes = [
     }
   },
   {
-    path: "/stats/:id",
-    name: "StatisticsView",
-    component: StatisticsView,
+    path: "/resource_statistics/:id",
+    name: "ResourceStatisticsView",
+    component: ResourceStatistics,
     meta: {
       requires_auth: true,
       is_admin: true,

--- a/src/store/domain-config/actions.js
+++ b/src/store/domain-config/actions.js
@@ -228,5 +228,16 @@ export default {
         return reject(e);
       }
     });
+  },
+  getIncidentsByResourceId(context, resourceId) {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      try {
+        let urlSearch = `/api/v1/resources/${resourceId}/incidents/`;
+        return resolve(await api.get(urlSearch));
+      } catch (e) {
+        return reject(e);
+      }
+    });
   }
 };

--- a/src/store/domain-config/actions.js
+++ b/src/store/domain-config/actions.js
@@ -219,28 +219,14 @@ export default {
     return incidentTypeData[0];
   },
   getStatisticsByResourceId(context, resourceId) {
-    if (resourceId) {
-      // eslint-disable-next-line no-async-promise-executor
-      return new Promise(async (resolve, reject) => {
-        try {
-          // TODO: Descomentar la línea de abajo, y borrar la hardcodeada cuando se calculen las estadísticas por id.
-          // let urlSearch = `/api/v1/statistics/${resourceId}/`;
-          let urlSearch = `/api/v1/statistics/`;
-          return resolve(await api.get(urlSearch));
-        } catch (e) {
-          return reject(e);
-        }
-      });
-    } else {
-      // eslint-disable-next-line no-async-promise-executor
-      return new Promise(async (resolve, reject) => {
-        try {
-          let urlSearch = `/api/v1/statistics/`;
-          return resolve(await api.get(urlSearch));
-        } catch (e) {
-          return reject(e);
-        }
-      });
-    }
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      try {
+        let urlSearch = `/api/v1/resources/${resourceId}/statistics/`;
+        return resolve(await api.get(urlSearch));
+      } catch (e) {
+        return reject(e);
+      }
+    });
   }
 };

--- a/src/views/IncidentMetrics.vue
+++ b/src/views/IncidentMetrics.vue
@@ -167,8 +167,9 @@ export default {
       .dispatch("incident/getIncidentById", this.incidentMetrics.id)
       .then(response => {
         this.incidentMetrics.incidentType = response.data.incident_type_name;
-        this.incidentMetrics.externalAssistance =
-          response.data.external_assistance;
+        this.incidentMetrics.externalAssistance = this.translateExternalAssistance(
+          response.data.external_assistance
+        );
         this.incidentMetrics.point = response.data.location_point;
         this.incidentMetrics.reference = response.data.reference;
         const options = {
@@ -413,6 +414,17 @@ export default {
       }
       timeInText = timeInText + afterText;
       return timeInText;
+    },
+    translateExternalAssistance(externalAssistance) {
+      switch (externalAssistance) {
+        case "With external support":
+          externalAssistance = "Con asistencia externa.";
+          break;
+        case "Without external support":
+          externalAssistance = "Sin asistencia externa.";
+          break;
+      }
+      return externalAssistance;
     }
   }
 };

--- a/src/views/ResourceManager.vue
+++ b/src/views/ResourceManager.vue
@@ -306,7 +306,7 @@ export default {
     },
     goToStatistics(resourceSelected) {
       this.$router.push({
-        name: "StatisticsView",
+        name: "ResourceStatisticsView",
         params: { id: resourceSelected.id }
       });
     },

--- a/src/views/ResourceManager.vue
+++ b/src/views/ResourceManager.vue
@@ -307,7 +307,7 @@ export default {
     goToStatistics(resourceSelected) {
       this.$router.push({
         name: "StatisticsView",
-        params: { id: resourceSelected.user.id }
+        params: { id: resourceSelected.id }
       });
     },
     async changeStateResource() {

--- a/src/views/ResourceStatistics.vue
+++ b/src/views/ResourceStatistics.vue
@@ -181,7 +181,7 @@ import BarChart from "@/components/charts/BarChart.vue";
 import { mapGetters } from "vuex";
 
 export default {
-  name: "StatisticsView.vue",
+  name: "ResourceStatistics",
   components: { BarChart, PieChart, LineChart },
   data() {
     return {

--- a/src/views/ResourceStatistics.vue
+++ b/src/views/ResourceStatistics.vue
@@ -24,7 +24,9 @@
               <v-card-title
                 >Cantidad total de participaciones en incidentes.</v-card-title
               >
-              <v-card-text justify="center"><h1>12</h1></v-card-text>
+              <v-card-text justify="center"
+                ><h1>{{ this.incidentsAttended }}</h1></v-card-text
+              >
               <v-card-subtitle
                 >Todas las participaciones en incidentes en las que el recurso
                 estuvo presente.</v-card-subtitle
@@ -186,6 +188,7 @@ export default {
   data() {
     return {
       resourceId: null,
+      incidentsAttended: 0,
       headerIncidentsTable: [
         { text: "Estado", sortable: false, value: "status" },
         {
@@ -272,6 +275,7 @@ export default {
         .dispatch("domainConfig/getIncidentsByResourceId", context.resourceId)
         .then(response => {
           let incidents = [];
+          this.incidentsAttended = response.data.results.length;
           if (response.data.results !== []) {
             response.data.results.forEach(item => {
               item = {

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -3,8 +3,9 @@
     <v-card class="pt-5 pr-1 pl-1 pb-1 mt-5 mr-1 ml-1 mb-1" color="">
       <v-card-title> <h1>Estadísticas por recurso.</h1></v-card-title>
       <v-card-subtitle
-        >Toda la expliación de las estadísticas y reportes
-        necesaria.</v-card-subtitle
+        >A continuación se detallarán las métricas obtenidas por la aplicación
+        por cada recurso. Además, se podrá visualizar el listado de incidentes
+        en los que el recurso participó.</v-card-subtitle
       >
       <v-card-text>
         <v-layout row class="pa-auto ma-auto" fill-height fill-width>
@@ -25,8 +26,8 @@
               >
               <v-card-text justify="center"><h1>12</h1></v-card-text>
               <v-card-subtitle
-                >Acá va la explicación de este número, explicar como leerlo y
-                qué representa.</v-card-subtitle
+                >Todas las participaciones en incidentes en las que el recurso
+                estuvo presente.</v-card-subtitle
               >
             </v-card>
           </v-row>
@@ -136,7 +137,6 @@
                   :data-collection="barChartData"
                 ></bar-chart
               ></v-card-text>
-              <v-card-subtitle>Notas extras.</v-card-subtitle>
             </v-card>
           </v-row>
           <v-row
@@ -166,7 +166,6 @@
                 >
                 </v-data-table>
               </v-card-text>
-              <v-card-subtitle>Notas extras.</v-card-subtitle>
             </v-card>
           </v-row>
         </v-layout>
@@ -244,9 +243,11 @@ export default {
     },
     async getStatisticsByResource() {
       let context = this;
+      console.log(context.resourceId);
       await context.$store
         .dispatch("domainConfig/getStatisticsByResourceId", context.resourceId)
         .then(response => {
+          console.log(response);
           context.barChartData = response.data.barChartData;
           context.lineChartDataAnnually = response.data.lineChartDataAnnually;
           context.lineChartDataMonthly = response.data.lineChartDataMonthly;
@@ -257,9 +258,6 @@ export default {
           console.error(
             "Error al intentar obtener las estadísticas por recurso."
           );
-        })
-        .finally(async () => {
-          console.log("Estadística por recurso obtenida con éxito.");
         });
     },
     goToMap(incident) {

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -228,7 +228,7 @@ export default {
       let context = this;
       // TODO: obtener todos los incidentes en los que participó un recurso en particular, pasandole la id del recurso en la request.
       await context.$store
-        .dispatch("incident/getIncident")
+        .dispatch("incident/getIncidentsByResourceId", context.resourceId)
         .then(response => {
           this.incidentsByResource = response.data.results;
         })

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -234,20 +234,13 @@ export default {
         })
         .catch(async () => {
           console.error("Error al buscar datos para llenar la tabla.");
-        })
-        .finally(async () => {
-          console.log(
-            "Búsqueda de datos para llenar la tabla finalizada con éxito."
-          );
         });
     },
     async getStatisticsByResource() {
       let context = this;
-      console.log(context.resourceId);
       await context.$store
         .dispatch("domainConfig/getStatisticsByResourceId", context.resourceId)
         .then(response => {
-          console.log(response);
           context.barChartData = response.data.barChartData;
           context.lineChartDataAnnually = response.data.lineChartDataAnnually;
           context.lineChartDataMonthly = response.data.lineChartDataMonthly;

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -274,7 +274,6 @@ export default {
           let incidents = [];
           if (response.data.results !== []) {
             response.data.results.forEach(item => {
-              console.log(item);
               item = {
                 status: this.translateStatus(item.incident.status),
                 data_status: this.translateDataStatus(
@@ -287,10 +286,8 @@ export default {
                   item.incident.location_as_string_reference
                 )
               };
-              console.log(item);
               incidents.push(item);
             });
-            console.log(incidents);
             this.incidentsByResource = incidents;
           }
         })

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -222,15 +222,77 @@ export default {
     await this.loadIncidentsDataByUser();
   },
   methods: {
+    translateStatus(status) {
+      switch (status) {
+        case "Started":
+          status = "Inicializado";
+          break;
+        case "Finalized":
+          status = "Finalizado";
+          break;
+        case "Canceled":
+          status = "Cancelado";
+          break;
+      }
+      return status;
+    },
+    translateDataStatus(dataStatus) {
+      switch (dataStatus) {
+        case "Incomplete":
+          dataStatus = "Incompleto";
+          break;
+        case "Complete":
+          dataStatus = "Completo";
+      }
+      return dataStatus;
+    },
+    translateExternalAssistance(externalAssistance) {
+      switch (externalAssistance) {
+        case "With external support":
+          externalAssistance = "Con asistencia externa.";
+          break;
+        case "Without external support":
+          externalAssistance = "Sin asistencia externa.";
+          break;
+      }
+      return externalAssistance;
+    },
+    translateLocationString(locationAsStringReference) {
+      if (locationAsStringReference === "") {
+        return "-";
+      } else {
+        return locationAsStringReference;
+      }
+    },
     async loadIncidentsDataByUser() {
       this.loadingTable = true;
 
       let context = this;
-      // TODO: obtener todos los incidentes en los que participó un recurso en particular, pasandole la id del recurso en la request.
       await context.$store
-        .dispatch("incident/getIncidentsByResourceId", context.resourceId)
+        .dispatch("domainConfig/getIncidentsByResourceId", context.resourceId)
         .then(response => {
-          this.incidentsByResource = response.data.results;
+          let incidents = [];
+          if (response.data.results !== []) {
+            response.data.results.forEach(item => {
+              console.log(item);
+              item = {
+                status: this.translateStatus(item.incident.status),
+                data_status: this.translateDataStatus(
+                  item.incident.data_status
+                ),
+                external_assistance: this.translateExternalAssistance(
+                  item.incident.external_assistance
+                ),
+                location_as_string_reference: this.translateLocationString(
+                  item.incident.location_as_string_reference
+                )
+              };
+              console.log(item);
+              incidents.push(item);
+            });
+            console.log(incidents);
+            this.incidentsByResource = incidents;
+          }
         })
         .catch(async () => {
           console.error("Error al buscar datos para llenar la tabla.");


### PR DESCRIPTION
closes #85 
closes #82 
- Se refactorizó la vista StatisticsView a ResourceStatistics. 
- Se cambiaron los path en el router de /stats/ a /resource_statistics/.
- Se cambiaron los endpoints consultados para obtener los incidentes por recurso y para obtener las estadísticas por recurso.
- Se traducieron todos los textos mostrados en inglés.
- Se quitaron los console.logs innecesarios, y se eliminaron las notas y textos redundantes.

La idea es dejar 100% lista esta vista, no debería quedar más nada por hacer. Esto se debe a que esta vista se debe migrar a mobile, por lo que una corrección a futuro se deberá duplicar el trabajo en los dos repositorios para mantener la simetría.

Pendiente: endpoint para obtener el número total de incidentes de un recurso en particular.